### PR TITLE
feat: support pipx run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 rich = 'rich_cli.__main__:run'
+
+[tool.poetry.plugins."pipx.run"]
+rich-cli = 'rich_cli.__main__:run'


### PR DESCRIPTION
Pipx (https://github.com/pypa/pipx) expects a package to have a console entry point matching the name of the package. If this is not the case (`rich-cli` package with `rich` after installing), then you can tell pipx this is the case by adding a pipx entry-point[^1].

```console
# before
pipx run --spec rich-cli rich <args>
# after
pipx run rich-cli <args>
```

[^1]: Entry-points are called plugin in Poetry, not to be confused with a poetry plugin, which will look like `[tool.poetry.plugins."poetry.plugin"]` :facepalm: