### PR TITLE
Fallback to TextLexer in case no lexer is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ rich loop.py -n -g
 
 ![syntax2](https://raw.githubusercontent.com/Textualize/rich-cli/main/imgs/syntax2.png)
 
-You can specify a [theme](https://pygments.org/styles/) with `--theme` or `-t`.
+You can specify a [theme](https://pygments.org/styles/) with `--theme`.
 
 ```
 rich loop.py --theme dracula

--- a/src/rich_cli/__main__.py
+++ b/src/rich_cli/__main__.py
@@ -2,6 +2,8 @@ import sys
 from typing import TYPE_CHECKING, List, NoReturn, Optional, Tuple
 
 import click
+from pygments.lexers.special import TextLexer
+from pygments.util import ClassNotFound
 from rich.console import Console, RenderableType
 from rich.markup import escape
 from rich.text import Text
@@ -98,6 +100,8 @@ def read_resource(path: str, lexer: Optional[str]) -> Tuple[str, Optional[str]]:
 
             lexer = guess_lexer_for_filename(path, text).name
         return (text, lexer)
+    except ClassNotFound:
+        return (text, TextLexer())
     except Exception as error:
         on_error(f"unable to read {escape(path)}", error)
 


### PR DESCRIPTION
Catch `ClassNotFound` exception from pygments when `guess_lexer_for_filename` fails, use [TextLexer](https://pygments.org/docs/lexers/#pygments.lexers.special.TextLexer) in this case.

Related #11 