### PR TITLE
update homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ pipx install rich-cli
 You can install Rich-CLI with [Homebew](https://brew.sh/).
 
 ```
-brew tap textualize/rich
 brew install rich
 ```
 


### PR DESCRIPTION
Rich-CLI is now in homebrew-core: https://github.com/Homebrew/homebrew-core/pull/94616