### PR TITLE
Improve CSV guessing

### DIFF
--- a/src/rich_cli/__main__.py
+++ b/src/rich_cli/__main__.py
@@ -719,8 +719,15 @@ def render_csv(
     try:
         dialect = sniffer.sniff(csv_data[:1024], delimiters=",\t|;")
         has_header = sniffer.has_header(csv_data[:1024])
-    except Exception as error:
-        on_error(str(error))
+    except csv.Error as error:
+        if resource.endswith(".csv"):
+            dialect = csv.get_dialect("excel")
+            has_header = True
+        elif resource.endswith(".tsv"):
+            dialect = csv.get_dialect("excel-tab")
+            has_header = True
+        else:
+            on_error(str(error))
 
     csv_file = io.StringIO(csv_data)
     reader = csv.reader(csv_file, dialect=dialect)

--- a/src/rich_cli/__main__.py
+++ b/src/rich_cli/__main__.py
@@ -717,7 +717,7 @@ def render_csv(
     csv_data, _ = read_resource(resource, "csv")
     sniffer = csv.Sniffer()
     try:
-        dialect = sniffer.sniff(csv_data[:1024])
+        dialect = sniffer.sniff(csv_data[:1024], delimiters=",\t|;")
         has_header = sniffer.has_header(csv_data[:1024])
     except Exception as error:
         on_error(str(error))


### PR DESCRIPTION
Changes:

- CSV delimiters are limited to `,`, `|`, `;`, or `\t`(mostly to exclude letters and digits from being delimiters)
- On sniffing errors, assume `,` or `\t` delimiter based on the file extension
- Fallback to assuming there is a header (works for my use cases? 🤷)

Fixes #38