### PR TITLE
Take `--theme` and `--lexer` into account for Markdown and RST

### DIFF
--- a/src/rich_cli/__main__.py
+++ b/src/rich_cli/__main__.py
@@ -561,13 +561,18 @@ def main(
         from rich.markdown import Markdown
 
         markdown_data, lexer = read_resource(resource, lexer)
-        renderable = Markdown(markdown_data, hyperlinks=hyperlinks)
+        renderable = Markdown(markdown_data, code_theme=theme, hyperlinks=hyperlinks)
 
     elif resource_format == RST:
         from rich_rst import RestructuredText
 
-        rst_data, lexter = read_resource(resource, lexer)
-        renderable = RestructuredText(rst_data, show_errors=False)
+        rst_data, _ = read_resource(resource, lexer)
+        renderable = RestructuredText(
+            rst_data,
+            code_theme=theme,
+            default_lexer=lexer or "python",
+            show_errors=False,
+        )
 
     elif resource_format == INSPECT:
         try:


### PR DESCRIPTION
### Details

The default value for the theme parameter is `ansi dark`, so now the new default theme for markdown will be `ansi dark`, which is consistent with viewing source code. However the default value for the code_theme in both Markdown and RestructuredText is `monokai`. And the default lexer for RST defaults to python since the RST language is mostly used with python. Renamed the `lexer` (`lexter :)`) variable to `_` since it will shadow the original lexer argument.

### Relevant Issue

Closes https://github.com/Textualize/rich-cli/issues/35