### PR TITLE
Fix generic blend text

### DIFF
--- a/src/rich_cli/__main__.py
+++ b/src/rich_cli/__main__.py
@@ -155,7 +155,7 @@ def blend_text(
     size = len(text)
     for index in range(size):
         blend = index / size
-        color = f"#{int(r1 + dr * blend):2X}{int(g1 + dg * blend):2X}{int(b1 + db * blend):2X}"
+        color = f"#{int(r1 + dr * blend):02X}{int(g1 + dg * blend):02X}{int(b1 + db * blend):02X}"
         text.stylize(color, index, index + 1)
     return text
 


### PR DESCRIPTION
`:2X` doesn't keep leading zeros, which means that if value was too close to 0, instead of having `00` we would have `` or instead of having `08` we would have ` 8`. This makes it so that the HEX code is incorrect.

This is minimal but was causing me troubles since my first color to blend has red 0. So hopefully it won't happen to anyone else 😄 

<img width="1682" alt="Screenshot 2022-05-12 at 12 03 32" src="https://user-images.githubusercontent.com/25267873/168056849-a458342d-4185-490c-9498-a99bcfa080f8.png">