### PR TITLE
Hard-code UTF-8 encoding for the input file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Rich-CLI now assumes that the input file is encoded in UTF-8 https://github.com/Textualize/rich-cli/pull/56
+
 ## [1.8.0] - 2022-05-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Rich CLI
+# Rich-CLI
 
-Rich-cli is a command line toolbox for fancy output in the terminal, built with [Rich](https://github.com/Textualize/rich).
+Rich-CLI is a command line toolbox for fancy output in the terminal, built with [Rich](https://github.com/Textualize/rich).
 
 Use the `rich` command to highlight a variety of file types in the terminal, with specialized rendering for Markdown and JSON files. Additionally you can markup and format text from the command line.
 

--- a/src/rich_cli/__main__.py
+++ b/src/rich_cli/__main__.py
@@ -102,7 +102,7 @@ def read_resource(path: str, lexer: Optional[str]) -> Tuple[str, Optional[str]]:
         if path == "-":
             return (sys.stdin.read(), None)
 
-        with open(path, "rt") as resource_file:
+        with open(path, "rt", encoding="utf8", errors="replace") as resource_file:
             text = resource_file.read()
         if not lexer:
             _, dot, ext = path.rpartition(".")


### PR DESCRIPTION
This is a first draft to fix the encoding errors described in #55 - i.e. we're on Windows and the input file is encoded in UTF-8.

##### The role of PYTHONIOENCODING, as described in the issue

The bug report mentions that even when the [PYTHONIOENCODING](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONIOENCODING) env var is set, the preferred encoding determined by Python on Windows is still a Windows-specific encoding.
However, it seems that this is actually pretty much the expected behaviour, as the behaviour of this env var seems to only affect stdin/stdout/stderr?
![PYTHONIOENCODING-not-changing-preferred-encoding](https://user-images.githubusercontent.com/722388/173562913-792ff701-1321-4ea8-b418-5ae097b1b425.png)

#### Potential breaking changes brought by this PR

Of course, assuming that the input file is _always_ encoded in UTF-8, like we do with this PR, could break some existing usages of Rich-CLI. Especially on Windows, where UTF-8 is still not the default encoding if I'm not wrong?
Not sure what would be the safest way to handle that issue? 🤔 

#### Potential ways to handler that better

- Maybe we could try to use the file using the system's default encoding first, and _then_, only if that failed, fall back to UTF-8?
    e.g. something like this: (pseudo-code)
    ```py
    for encoding in (None, "utf8"):
       try:
         with open(path, "rt", encoding=encoding) as resource_file:
       except EncodingError:
         continue
    ```
  
- As pointed out by @darrenburns , there is now the possibility to use a [PYTHONUTF8](https://peps.python.org/pep-0540/) env var, which seems to work:
![using-PYTHONUTF8](https://user-images.githubusercontent.com/722388/173569356-7f3a7f3e-0aeb-4116-9f68-b17cf0300570.png)
  
- Add a flag and/or an env var specific to Rich-CLI to let the user tell Rich-CLI which encoding we should use to open the input file?  
  Maybe that would be the most flexible option, combined to a "_before raising an exception, fall back to UTF-8 if the default encoding didn't work_" strategy? What do you think @willmcgugan @darrenburns ? :slightly_smiling_face: 

#### Before / After

##### Before this fix:

![before-utf8-fix](https://user-images.githubusercontent.com/722388/173561662-aa9edc47-1ba7-4d40-a836-e3d20bb92c04.png)

##### After this fix:

![after-utf8-fix cmd](https://user-images.githubusercontent.com/722388/173561709-dabf444b-ab4e-4ddd-9bdf-d3f285d5c883.png)


fixes #55 