### PR TITLE
Add support for setting `--hyperlinks` via the `RICH_HYPERLINKS` environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.9.0] - 2022-07-31
 
 ### Changed
 
 - Rich-CLI now assumes that the input file is encoded in UTF-8 https://github.com/Textualize/rich-cli/pull/56
+- Add support for setting `--hyperlinks` via the `RICH_HYPERLINKS` environment variable https://github.com/Textualize/rich-cli/pull/58
 
 ## [1.8.0] - 2022-05-07
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ If your terminal supports hyperlinks, you can add `--hyperlinks` or `-y` which w
 rich README.md --hyperlinks
 ```
 
+This can also be set via the `RICH_HYPERLINKS` environment variable. So the following is equivalent to the above command:
+
+```
+RICH_HYPERLINKS=true rich README.md
+```
+
 ## Jupyter notebook
 
 You can request Jupyter notebook rendering by adding the `--ipynb` switch. If the file ends with `.ipynb` Jupyter notebook will be auto-detected.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "rich-cli"
 homepage = "https://github.com/Textualize/rich-cli"
-version = "1.8.0"
+version = "1.9.0"
 description = "Command Line Interface to Rich"
 authors = ["Will McGugan <willmcgugan@gmail.com>"]
 license = "MIT"

--- a/src/rich_cli/__main__.py
+++ b/src/rich_cli/__main__.py
@@ -37,7 +37,7 @@ COMMON_LEXERS = {
     "toml": "toml",
 }
 
-VERSION = "1.8.0"
+VERSION = "1.9.0"
 
 
 AUTO = 0
@@ -370,7 +370,13 @@ class RichCommand(click.Command):
     default=None,
     help="Use [b]LEXER[/b] for syntax highlighting. [dim]See https://pygments.org/docs/lexers/",
 )
-@click.option("--hyperlinks", "-y", is_flag=True, help="Render hyperlinks in markdown.")
+@click.option(
+    "--hyperlinks",
+    "-y",
+    is_flag=True,
+    help="Render hyperlinks in markdown.",
+    envvar="RICH_HYPERLINKS",
+)
 @click.option(
     "--no-wrap", is_flag=True, help="Don't word wrap syntax highlighted files."
 )


### PR DESCRIPTION
Small commit to allow setting `--hyperlinks` via the `RICH_HYPERLINKS` environment variable, so users can export this in their shell rc file and always have hyperlinks enabled.

![Kapture 2022-07-31 at 09 26 11](https://user-images.githubusercontent.com/7277377/182028547-e4be06da-d48d-44b8-b913-f6a7a4d2914f.gif)
