### PR TITLE
Added option to override CSV default header detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added option to override csv header detection
+
 ### Changed
 
 - Rich-CLI now assumes that the input file is encoded in UTF-8 https://github.com/Textualize/rich-cli/pull/56

--- a/src/rich_cli/__main__.py
+++ b/src/rich_cli/__main__.py
@@ -261,6 +261,7 @@ class RichCommand(click.Command):
 @click.option("--ipynb", is_flag=True, help="Display [u]Jupyter notebook[/u].")
 @click.option("--syntax", is_flag=True, help="[u]Syntax[/u] highlighting.")
 @click.option("--inspect", is_flag=True, help="[u]Inspect[/u] a python object.")
+@click.option("--header", type=bool, metavar="BOOL", default=None, help="Overrides the CSV [u]header[/u] detection (requires --csv).")
 @click.option(
     "--head",
     "-h",
@@ -410,6 +411,7 @@ def main(
     csv: bool = False,
     ipynb: bool = False,
     inspect: bool = True,
+    header: Optional[bool] = None,
     emoji: bool = False,
     left: bool = False,
     right: bool = False,
@@ -607,7 +609,7 @@ def main(
 
     elif resource_format == CSV:
 
-        renderable = render_csv(resource, head, tail, title, caption)
+        renderable = render_csv(resource, head, tail, title, caption, header)
 
     elif resource_format == IPYNB:
 
@@ -739,6 +741,7 @@ def render_csv(
     tail: Optional[int] = None,
     title: Optional[str] = None,
     caption: Optional[str] = None,
+    header: Optional[bool] = None,
 ) -> RenderableType:
     """Render resource as CSV.
 
@@ -771,6 +774,9 @@ def render_csv(
             has_header = True
         else:
             on_error(str(error))
+    finally:
+        if header is not None:
+            has_header = header
 
     csv_file = io.StringIO(csv_data)
     reader = csv.reader(csv_file, dialect=dialect)


### PR DESCRIPTION
Noticed it didnt display the header for some CSVs due to the std CSV lib header detection not being perfect (https://docs.python.org/3/library/csv.html#csv.Sniffer.has_header), so added a click option to override the default detection.