### PR TITLE
Add GNU "less" style navigation shortcuts to --pager view

### DIFF
--- a/src/rich_cli/pager.py
+++ b/src/rich_cli/pager.py
@@ -87,12 +87,14 @@ class PagerApp(App):
             # half page-up
             self.body.target_y -= self.body.size.height // 2
             self.body.y = self.body.target_y
-        elif event.key == "1":
-            # jump to home ; shorthand for the "less" command "1 -> Shift+G"
+        elif event.key == "g" or event.key == "1" :
+            # jump to first line 
+            # "g" is the "less" version; "1" is a shorthand for the "vi" command "1 -> Shift+G"
             self.body.target_x = self.body.target_y = 0
             self.body.x = self.body.y = 0
         elif event.key == "G":
-            # jump to end 
+            # jump to last line
+            # Same shortcut in both "less" and "vi"
             self.body.target_x = 0
             self.body.target_y = self.body.window.virtual_size.height - self.body.size.height
             self.body.x, self.body.y = self.body.target_x, self.body.target_y

--- a/src/rich_cli/pager.py
+++ b/src/rich_cli/pager.py
@@ -71,6 +71,31 @@ class PagerApp(App):
         elif event.key == "ctrl+d":
             self.body.target_y += self.body.size.height // 2
             self.body.animate("y", self.body.target_y, easing="out_cubic")
+        elif event.key == "f":
+            # page down
+            self.body.target_y += self.body.size.height
+            self.body.y = self.body.target_y
+        elif event.key == "b":
+            # page up
+            self.body.target_y -= self.body.size.height
+            self.body.y = self.body.target_y
+        elif event.key == "d":
+            # half page-down
+            self.body.target_y += self.body.size.height // 2
+            self.body.y = self.body.target_y
+        elif event.key == "u":
+            # half page-up
+            self.body.target_y -= self.body.size.height // 2
+            self.body.y = self.body.target_y
+        elif event.key == "1":
+            # jump to home ; shorthand for the "less" command "1 -> Shift+G"
+            self.body.target_x = self.body.target_y = 0
+            self.body.x = self.body.y = 0
+        elif event.key == "G":
+            # jump to end 
+            self.body.target_x = 0
+            self.body.target_y = self.body.window.virtual_size.height - self.body.size.height
+            self.body.x, self.body.y = self.body.target_x, self.body.target_y
 
     async def on_mount(self, event: events.Mount) -> None:
         self.body = body = ScrollView(auto_width=True)


### PR DESCRIPTION
Closes #101 . 

Adds the following single-key navigation shortcuts used in [GNU `less`](https://ss64.com/bash/less.html):

| Shortcut | Action |
| --- | --- | 
| `f` | page down (forward one window) |
| `b` | page up (backward one window) |
| `d` | half-page down (forward half window) |
| `u` | half-page up (backward half window) |
| `g` OR `1` | jump to first line (`1` is a shorthand for the `1`+`G` jump in `vi` ) |
| `G` | jump to last line (same in `less` and in `vi`) |

Since the `less` navigation does not animate its movements, I chose to do the same with the corresponding actions.
I also neglected to include the `e` and `y` one-line movements, since I wasn't sure how to make that happen (and because I didn't know they existed until I looked at the help while writing this PR 😂 ).

I didn't see a `contribution.md` in the repo, but let me know if there's any reformatting or style changes you would like. I'm happy to make corrections to the PR.

Recommend squash-and-merge if accepted.
