### PR TITLE
feat: add --no-pager-animation flag to disable scroll animation

### DIFF
--- a/src/rich_cli/__main__.py
+++ b/src/rich_cli/__main__.py
@@ -396,6 +396,11 @@ class RichCommand(click.Command):
     "--export-svg", metavar="PATH", default="", help="Write SVG to [b]PATH[/b]."
 )
 @click.option("--pager", is_flag=True, help="Display in an interactive pager.")
+@click.option(
+    "--no-pager-animation",
+    is_flag=True,
+    help="Disable scroll animation in the interactive pager.",
+)
 @click.option("--version", "-v", is_flag=True, help="Print version and exit.")
 def main(
     resource: str,
@@ -441,6 +446,7 @@ def main(
     export_html: str = "",
     export_svg: str = "",
     pager: bool = False,
+    no_pager_animation: bool = False,
 ):
     """Rich toolbox for console output."""
     if version:
@@ -707,7 +713,11 @@ def main(
             width = console.width
         render_options = console.options.update(width=width - 1)
         lines = console.render_lines(renderable, render_options, new_lines=True)
-        PagerApp.run(title=resource, content=PagerRenderable(lines, width=width))
+        PagerApp.run(
+            title=resource,
+            content=PagerRenderable(lines, width=width),
+            disable_animation=no_pager_animation,
+        )
 
     else:
         try:

--- a/src/rich_cli/pager.py
+++ b/src/rich_cli/pager.py
@@ -50,9 +50,11 @@ class PagerApp(App):
         self,
         *args,
         content=None,
+        disable_animation=False,
         **kwargs,
     ) -> None:
         self.content = content
+        self.disable_animation = disable_animation
         super().__init__(*args, **kwargs)
 
     async def on_load(self, event: events.Load) -> None:
@@ -67,10 +69,16 @@ class PagerApp(App):
             self.body.page_down()
         elif event.key == "ctrl+u":
             self.body.target_y -= self.body.size.height // 2
-            self.body.animate("y", self.body.target_y, easing="out_cubic")
+            if not self.disable_animation:
+                self.body.animate("y", self.body.target_y, easing="out_cubic")
+            else:
+                self.body.y = self.body.target_y
         elif event.key == "ctrl+d":
             self.body.target_y += self.body.size.height // 2
-            self.body.animate("y", self.body.target_y, easing="out_cubic")
+            if not self.disable_animation:
+                self.body.animate("y", self.body.target_y, easing="out_cubic")
+            else:
+                self.body.y = self.body.target_y
 
     async def on_mount(self, event: events.Mount) -> None:
         self.body = body = ScrollView(auto_width=True)


### PR DESCRIPTION
## What

Add a `--no-pager-animation` CLI flag to disable the animated scrolling when using `ctrl+u` / `ctrl+d` in the interactive pager.

## Why

The scrolling animation in the pager (`PagerApp`) uses `out_cubic` easing which feels slow for some users. This flag allows disabling it for instant page up/down, similar to `less` behavior.

Closes #132

## Testing

- [x] Verified `--no-pager-animation` flag is accepted by click
- [x] Verified flag is passed to `PagerApp`
- [x] Python syntax check passes for both modified files

## Changes

- `src/rich_cli/pager.py`: Add `disable_animation` parameter to `PagerApp.__init__`, skip `animate()` call when set
- `src/rich_cli/__main__.py`: Add `--no-pager-animation` CLI option, pass to `PagerApp.run()`