### PR TITLE
Remove hardcoded dark background from inline markdown code

### DIFF
--- a/src/rich_cli/__main__.py
+++ b/src/rich_cli/__main__.py
@@ -446,10 +446,19 @@ def main(
     if version:
         sys.stdout.write(f"{VERSION}\n")
         return
+    from rich.theme import Theme
+
     console = Console(
         emoji=emoji,
         record=bool(export_html or export_svg),
         force_terminal=force_terminal if force_terminal else None,
+        theme=Theme(
+            {
+                # Override Rich's dark defaults for readable inline/block code.
+                "markdown.code": "bold cyan",
+                "markdown.code_block": "cyan",
+            }
+        ),
     )
 
     def print_usage() -> None:


### PR DESCRIPTION
Rich's default markdown.code style is 'bold cyan on black', which is unreadable on light terminals. Override the console theme to drop the black background so inline and block code adapt to the terminal.

Inline code can not be changed by `--theme`.

Looks like this before the change:

`uv run -w rich python -m rich.default_styles`

<img width="537" height="329" alt="image" src="https://github.com/user-attachments/assets/df14f4f1-1468-4707-a342-302c2b712ad9" />

